### PR TITLE
Make all feature-related deps optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 members = [ "cpu", "profiler", "storage", "time", "timed", "timer" ]
 
 [dependencies]
-aleo-std-cpu = { path = "./cpu", version = "0.1.3", default-features = false }
+aleo-std-cpu = { path = "./cpu", version = "0.1.3", default-features = false, optional = true }
 aleo-std-profiler = { path = "./profiler", version = "0.1.3", default-features = false }
 aleo-std-storage = { path = "./storage", version = "0.1.3", default-features = false, optional = true }
 aleo-std-time = { path = "./time", version = "0.1.0", default-features = false }
@@ -31,6 +31,7 @@ wasm = []
 
 # aleo-std feature configuration
 
+cpu = ["aleo-std-cpu"]
 profiler = ["aleo-std-profiler/profiler"]
 storage = ["aleo-std-storage"]
 time = ["aleo-std-time/time"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [ "cpu", "profiler", "storage", "time", "timed", "timer" ]
 [dependencies]
 aleo-std-cpu = { path = "./cpu", version = "0.1.3", default-features = false }
 aleo-std-profiler = { path = "./profiler", version = "0.1.3", default-features = false }
-aleo-std-storage = { path = "./storage", version = "0.1.3", default-features = false }
+aleo-std-storage = { path = "./storage", version = "0.1.3", default-features = false, optional = true }
 aleo-std-time = { path = "./time", version = "0.1.0", default-features = false }
 aleo-std-timed = { path = "./timed", version = "0.1.2", default-features = false }
 aleo-std-timer = { path = "./timer", version = "0.1.1", default-features = false }
@@ -32,6 +32,7 @@ wasm = []
 # aleo-std feature configuration
 
 profiler = ["aleo-std-profiler/profiler"]
+storage = ["aleo-std-storage"]
 time = ["aleo-std-time/time"]
 timed = ["aleo-std-timed/timed"]
 timer = ["aleo-std-timer/timer"]

--- a/profiler/Cargo.toml
+++ b/profiler/Cargo.toml
@@ -11,4 +11,5 @@ version = "2"
 optional = true
 
 [features]
+default = []
 profiler = [ "colored" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,13 @@
 
 pub use aleo_std_cpu::{get_cpu, Cpu};
 pub use aleo_std_profiler::*;
+#[cfg(feature = "storage")]
 pub use aleo_std_storage::{aleo_dir, aleo_ledger_dir, aleo_operator_dir, aleo_prover_dir};
 
 pub mod prelude {
     pub use aleo_std_cpu::{get_cpu, Cpu};
     pub use aleo_std_profiler::*;
+    #[cfg(feature = "storage")]
     pub use aleo_std_storage::{aleo_dir, aleo_ledger_dir, aleo_operator_dir, aleo_prover_dir};
     pub use aleo_std_time::time;
     pub use aleo_std_timed::timed;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with the aleo-std library. If not, see <https://www.gnu.org/licenses/>.
 
+#[cfg(feature = "cpu")]
 pub use aleo_std_cpu::{get_cpu, Cpu};
 pub use aleo_std_profiler::*;
 #[cfg(feature = "storage")]
 pub use aleo_std_storage::{aleo_dir, aleo_ledger_dir, aleo_operator_dir, aleo_prover_dir};
 
 pub mod prelude {
+    #[cfg(feature = "cpu")]
     pub use aleo_std_cpu::{get_cpu, Cpu};
     pub use aleo_std_profiler::*;
     #[cfg(feature = "storage")]

--- a/time/src/lib.rs
+++ b/time/src/lib.rs
@@ -16,15 +16,20 @@
 
 // With credits to PhilipDaniels/logging_timer.
 
+#[cfg(feature = "time")]
 #[macro_use]
 extern crate quote;
+#[cfg(feature = "time")]
 #[macro_use]
 extern crate syn;
 extern crate proc_macro;
 
+#[cfg(feature = "time")]
 const DEFAULT_LEVEL: &str = "debug";
+#[cfg(feature = "time")]
 const DEFAULT_NAME_PATTERN: &str = "{}";
 
+#[cfg(feature = "time")]
 fn extract_literal(token_tree: &proc_macro::TokenTree) -> String {
     let s = match token_tree {
         proc_macro::TokenTree::Literal(literal) => literal.to_string(),
@@ -40,6 +45,7 @@ fn extract_literal(token_tree: &proc_macro::TokenTree) -> String {
 
 // We also allow 'Never' to mean disable timer instrumentation
 // altogether. Any casing is allowed.
+#[cfg(feature = "time")]
 fn get_log_level_and_name_pattern(metadata: proc_macro::TokenStream) -> (String, String) {
     // Grab everything into a vector and filter out any intervening punctuation
     // (commas come through as TokenTree::Punct(_)).
@@ -99,6 +105,7 @@ fn get_log_level_and_name_pattern(metadata: proc_macro::TokenStream) -> (String,
     }
 }
 
+#[cfg(feature = "time")]
 fn get_timer_name(name_pattern: &str, function_name: &str) -> String {
     let function_name_with_parenthesis = format!("{}()", function_name);
     let timer_name = name_pattern.replacen("{}", &function_name_with_parenthesis, 1);

--- a/timer/Cargo.toml
+++ b/timer/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2018"
 
 [dependencies.colored]
 version = "2"
+optional = true
 
 [features]
 default = []
-timer = []
+timer = [ "colored" ]


### PR DESCRIPTION
This PR facilitates efforts like https://github.com/AleoHQ/snarkVM/issues/1097 and https://github.com/AleoHQ/snarkVM/issues/1099, by allowing the related dependencies to be pruned if the feature is not actually used.

The only follow-up change needed on snarkVM side is to add `features = ["storage"]` to `aleo-std` in `snarkvm-parameters`.