### PR TITLE
Fix overflow bug

### DIFF
--- a/profiler/src/lib.rs
+++ b/profiler/src/lib.rs
@@ -94,7 +94,7 @@ pub mod inner {
                 end_info,
                 message,
                 final_time,
-                pad = 75 - indent_amount
+                pad = 75usize.saturating_sub(indent_amount)
             );
         }};
     }
@@ -201,5 +201,17 @@ mod tests {
         let start = start_timer!(|| "Hello");
         add_to_trace!(|| "HelloMsg", || "Hello, I\nAm\nA\nMessage");
         end_timer!(start);
+    }
+
+    #[test]
+    fn print_nested_message() {
+        let mut starts = vec![];
+        for _ in 0..100 {
+            starts.push(start_timer!(|| "Hello"));
+        }
+        add_to_trace!(|| "HelloMsg", || "Hello, I\nAm\nA\nMessage");
+        for i in 0..100 {
+            end_timer!(starts[i]);
+        }
     }
 }


### PR DESCRIPTION
When running many tests in parallel (which is the default) with the profiler turned on, an overflow would silently be triggered causing tests to fail. This happened specifically in the snarkVM/algorithms/src/snark repo which has 80 sometimes heavy tests.

This closes https://github.com/AleoHQ/aleo-std/issues/3

I think we can either:
1. quickfix to remove the overflow (this PR)
2. properly fix indenting to whatever was the original goal ([and to learn Rust fmt's magic](https://doc.rust-lang.org/std/fmt/index.html)). I'm happy to open a new issue if its important to anyone.
3. add an `assert!(indent_amount < 75)` so at least we fail loud and clear about the reason

I appended pictures of the before and after stdout - essentially the runtime of different functions is not aligned anymore.

This PR             |  Original
:-------------------------:|:-------------------------:
![Screenshot from 2023-02-08 22-56-40](https://user-images.githubusercontent.com/24724627/217661846-c6c195a0-4edb-443d-b10f-837a009450cc.png)  |  ![Screenshot from 2023-02-08 22-56-49](https://user-images.githubusercontent.com/24724627/217661865-fa11614c-a1e9-4834-b10d-852b84c5e16f.png)
