### PR TITLE
Remove timer overflow underflow

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,15 +1,15 @@
 # https://github.com/rust-lang/rustfmt/blob/master/Configurations.md
 
 # Stable configurations
-edition = "2018"
+edition = "2021"
 max_width = 120
 merge_derives = true
 use_field_init_shorthand = true
+use_small_heuristics = "Max"
 use_try_shorthand = true
 
 # Nightly configurations
 imports_layout = "HorizontalVertical"
-license_template_path = ".resources/license_header"
 imports_granularity = "Crate"
 overflow_delimited_expr = true
 reorder_impl_items = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "aleo-std"
-version = "0.1.15"
+version = "0.1.18"
 dependencies = [
  "aleo-std-cpu",
  "aleo-std-profiler",
@@ -17,11 +17,11 @@ dependencies = [
 
 [[package]]
 name = "aleo-std-cpu"
-version = "0.1.3"
+version = "0.1.4"
 
 [[package]]
 name = "aleo-std-profiler"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "colored",
 ]
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "aleo-std-time"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -42,20 +42,10 @@ pub(crate) mod native_cpuid {
 
             // Safety: CPUID is supported on all x86_64 CPUs and all x86 CPUs with SSE, but not by SGX.
             let result = unsafe { arch::__cpuid_count(a, c) };
-            return CpuIdResult {
-                eax: result.eax,
-                ebx: result.ebx,
-                ecx: result.ecx,
-                edx: result.edx,
-            };
+            return CpuIdResult { eax: result.eax, ebx: result.ebx, ecx: result.ecx, edx: result.edx };
         }
 
-        CpuIdResult {
-            eax: 22,
-            ebx: 1970169159,
-            ecx: 1818588270,
-            edx: 1231384169,
-        }
+        CpuIdResult { eax: 22, ebx: 1970169159, ecx: 1818588270, edx: 1231384169 }
     }
 }
 
@@ -109,11 +99,7 @@ pub fn get_cpu() -> Cpu {
 
     match is_leaf_supported {
         true => {
-            let vendor = VendorInfo {
-                ebx: vendor_leaf.ebx,
-                ecx: vendor_leaf.ecx,
-                edx: vendor_leaf.edx,
-            };
+            let vendor = VendorInfo { ebx: vendor_leaf.ebx, ecx: vendor_leaf.ecx, edx: vendor_leaf.edx };
 
             match vendor.as_str() {
                 "AuthenticAMD" => Cpu::AMD,

--- a/profiler/src/lib.rs
+++ b/profiler/src/lib.rs
@@ -45,10 +45,7 @@ pub mod inner {
 
             println!("{}{:8} {}", indent, start_info, msg);
             NUM_INDENT.fetch_add(1, Ordering::Relaxed);
-            $crate::TimerInfo {
-                msg: msg.to_string(),
-                time: Instant::now(),
-            }
+            $crate::TimerInfo { msg: msg.to_string(), time: Instant::now() }
         }};
     }
 
@@ -83,9 +80,7 @@ pub mod inner {
             let message = format!("{} {}", $time.msg, $msg());
 
             NUM_INDENT
-                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |x| {
-                    if x > 0 { Some(x - 1) } else { Some(x) }
-                })
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |x| if x > 0 { Some(x - 1) } else { Some(x) })
                 .unwrap();
             let indent_amount = NUM_INDENT.load(Ordering::Relaxed).saturating_mul(2usize);
             let indent = compute_indent(indent_amount);

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -149,28 +149,16 @@ mod tests {
 
     #[test]
     fn test_aleo_ledger_dir() {
-        println!(
-            "{:?} exists: {:?}",
-            aleo_ledger_dir(2, None),
-            aleo_ledger_dir(2, None).exists()
-        );
+        println!("{:?} exists: {:?}", aleo_ledger_dir(2, None), aleo_ledger_dir(2, None).exists());
     }
 
     #[test]
     fn test_aleo_operator_dir() {
-        println!(
-            "{:?} exists: {:?}",
-            aleo_operator_dir(2, None),
-            aleo_operator_dir(2, None).exists()
-        );
+        println!("{:?} exists: {:?}", aleo_operator_dir(2, None), aleo_operator_dir(2, None).exists());
     }
 
     #[test]
     fn test_aleo_prover_dir() {
-        println!(
-            "{:?} exists: {:?}",
-            aleo_prover_dir(2, None),
-            aleo_prover_dir(2, None).exists()
-        );
+        println!("{:?} exists: {:?}", aleo_prover_dir(2, None), aleo_prover_dir(2, None).exists());
     }
 }


### PR DESCRIPTION
When proving large batches of circuits, the profiler messages still crashed.

I see the `cargo fmt` and `Cargo.lock` cleanup may conflict with the other open PR. Feel free to just use the single commit afc1183cd02f58ed4de8fa4910260e7e82e374a4 or ask me to rebase if the other PR is approved.