### PR TITLE
reflect license change in Cargo.toml files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.2"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A standard library for Aleo repositories"
 exclude = ["**/*.md"]
-license = "GPL-3.0"
+license = "Apache-2.0"
 edition = "2021"
 
 [workspace]

--- a/cpu/Cargo.toml
+++ b/cpu/Cargo.toml
@@ -3,5 +3,5 @@ name = "aleo-std-cpu"
 version = "1.0.2"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Convenience method for retrieving CPU information"
-license = "GPL-3.0"
+license = "Apache-2.0"
 edition = "2021"

--- a/profiler/Cargo.toml
+++ b/profiler/Cargo.toml
@@ -3,7 +3,7 @@ name = "aleo-std-profiler"
 version = "1.0.2"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A profiler to measure runtime performance"
-license = "GPL-3.0"
+license = "Apache-2.0"
 edition = "2021"
 
 [dependencies.colored]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -3,7 +3,7 @@ name = "aleo-std-storage"
 version = "1.0.2"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "Convenience methods for accessing resources in Aleo storage"
-license = "GPL-3.0"
+license = "Apache-2.0"
 edition = "2021"
 
 [dependencies.dirs]

--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -3,7 +3,7 @@ name = "aleo-std-time"
 version = "1.0.2"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A convenience attribute to time functions"
-license = "GPL-3.0"
+license = "Apache-2.0"
 edition = "2021"
 
 [lib]

--- a/timed/Cargo.toml
+++ b/timed/Cargo.toml
@@ -3,7 +3,7 @@ name = "aleo-std-timed"
 version = "1.0.2"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A profiler to conveniently time function executions"
-license = "GPL-3.0"
+license = "Apache-2.0"
 edition = "2021"
 
 [lib]

--- a/timer/Cargo.toml
+++ b/timer/Cargo.toml
@@ -3,7 +3,7 @@ name = "aleo-std-timer"
 version = "1.0.2"
 authors = [ "The Aleo Team <hello@aleo.org>" ]
 description = "A timer to conveniently time code blocks"
-license = "GPL-3.0"
+license = "Apache-2.0"
 edition = "2021"
 
 [dependencies.colored]


### PR DESCRIPTION
@vicsn @raychu86 

Sorry to do this after the previous release, but it appears that GPL wasn't removed from the Cargo.toml files.

This prevents using tools like cargo-deny to check licenses.